### PR TITLE
Automatically configure `snowflake_vcr` Pytest marker

### DIFF
--- a/src/snowflake/vcrpy/snowflake_vcrpy_pytest_plugin.py
+++ b/src/snowflake/vcrpy/snowflake_vcrpy_pytest_plugin.py
@@ -61,6 +61,12 @@ def _process_response_recording(response):
     return response
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "snowflake_vcr: Mark the test as using Snowflake VCR."
+    )
+
+
 @pytest.fixture(autouse=True)
 def _snowflake_vcr_marker(request):
     snowflake_record_mode = request.config.getoption(


### PR DESCRIPTION
Similar to the `pytest-vcr` library, this automatically registers the `snowflake_vcr` marker, avoiding the need to explicitly add this to a `pytest.ini` file.

Follows Pytest recommended approach - https://docs.pytest.org/en/latest/example/markers.html#custom-marker-and-command-line-option-to-control-test-runs